### PR TITLE
Add rate limiting to TornApi Service.

### DIFF
--- a/Exceptions/AllKeysRateLimitedException.cs
+++ b/Exceptions/AllKeysRateLimitedException.cs
@@ -1,0 +1,35 @@
+// TornBot
+// 
+// Copyright (C) 2024 TornBot.com
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+// 
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace TornBot.Exceptions;
+
+public class AllKeysRateLimitedException : Exception
+{
+    public AllKeysRateLimitedException()
+    {
+    }
+
+    public AllKeysRateLimitedException(string message)
+        : base(message)
+    {
+    }
+
+    public AllKeysRateLimitedException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}

--- a/TornBot.csproj
+++ b/TornBot.csproj
@@ -42,7 +42,7 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <Content Include="Migrations\*">
+    <Content Include="Migrations\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>sql\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>


### PR DESCRIPTION
Add rate limiting to TornApi Service.
Currently set to 10 calls per minute per key